### PR TITLE
Configure pythia sample for low-q2 kinematics

### DIFF
--- a/configuration/run.config
+++ b/configuration/run.config
@@ -13,6 +13,10 @@
             "location" : "<where-the-mobo-goes>/LowQ2-MOBO/steering/electron",
             "type"     : "gps"
         }
+"pythia6" : {
+            "location" : "<where-the-mobo-goes>/LowQ2-MOBO/steering/pythia",
+            "type"     : "hepmc"
+        }
     },
     "rec_exec"    : "eicrecon",
     "rec_collect" : [

--- a/steering/pythia/pythia6.nc10x130q1to10.py
+++ b/steering/pythia/pythia6.nc10x130q1to10.py
@@ -1,6 +1,0 @@
-from DDSim.DD4hepSimulation import DD4hepSimulation
-
-SIM = DD4hepSimulation()
-
-SIM.inputFiles     = "root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/DIS/pythia6.428-1.0/NC/noRad/ep/10x130/q2_1to10/pythia6.428-1.0_NC_noRad_ep_10x130_q2_1to10_ab.hepmc3.tree.root"
-SIM.numberOfEvents = 1000

--- a/steering/pythia/pythia6.nc18x275q0to1.py
+++ b/steering/pythia/pythia6.nc18x275q0to1.py
@@ -1,0 +1,10 @@
+from DDSim.DD4hepSimulation import DD4hepSimulation
+from g4units import m
+
+SIM = DD4hepSimulation()
+
+SIM.runType          = "run"
+SIM.physics.rangecut = 100.0*m
+
+SIM.inputFiles     = "root://dtn-eic.jlab.org//volatile/eic/EPIC/EVGEN/SIDIS/pythia6-eic/1.0.0/18x275/q2_0to1/pythia_ep_noradcor_18x275_q2_0.000000001_1.0_run1.ab.hepmc3.tree.root"
+SIM.numberOfEvents = 100000


### PR DESCRIPTION
Changes the target pythia sample so it can be used. The kinematic sample needs to be 18x275 for use with the epic_ip6_extended configuration and have a Q2 range below 1GeV to see hits in the Low-Q2  tagger.