### PR TITLE
Allow command line arguments to be added via the run config

### DIFF
--- a/EICMOBOTestTools/RecGenerator.py
+++ b/EICMOBOTestTools/RecGenerator.py
@@ -81,12 +81,16 @@ class RecGenerator:
                 collects = collects + collect
             icollect = icollect + 1
 
+        otherArgs= ""
+        for arg in self.cfgRun["rec_args"]:
+            otherArgs = otherArgs + " " + arg
+
         # construct output arguments
         outArg  = "-Ppodio:output_file=" + outDir + "/" + outFile
         collArg = "-Ppodio:output_collections=" + collects
 
         # construct most of command
-        command = self.cfgRun["rec_exec"] + " " + outArg + " " + collArg
+        command = self.cfgRun["rec_exec"] + " " + outArg + " " + collArg + " " + otherArgs
         for param, unitsAndValue in self.argParams.items():
             units, value = unitsAndValue
             if units != '': 

--- a/EICMOBOTestTools/SimGenerator.py
+++ b/EICMOBOTestTools/SimGenerator.py
@@ -102,8 +102,12 @@ class SimGenerator:
         steerer = " --steeringFile " + path + "/" + steer
         output  = " --outputFile " + outDir + "/" + outFile
 
+        otherArgs= ""
+        for arg in self.cfgRun["sim_args"]:
+            otherArgs = otherArgs + " " + arg
+
         # construct most of command
-        command = self.cfgRun["sim_exec"] + compact + steerer
+        command = self.cfgRun["sim_exec"] + compact + steerer + otherArgs
         if inType == "gun":
             command = command + " -G "
         elif inType == "gps":

--- a/examples/run_withEICreconInstallSpecified.config
+++ b/examples/run_withEICreconInstallSpecified.config
@@ -24,6 +24,9 @@
         "TaggerTrackerM2LocalTracks",
         "TaggerTrackerReconstructedParticles"
     ],
+    "rec_args" : [
+        "-Pplugins_to_ignore=janatop,LUMISPECCAL,ECTOF,BTOF,FOFFMTRK,RPOTS,B0TRK,MPGD,ECTRK,DRICH,DIRC,pid,tracking,EEMC,BEMC,FEMC,EHCAL,BHCAL,FHCAL,B0ECAL,ZDC,BTRK,BVTX,PFRICH,richgeo,evaluator,pid_lut,reco,rootfile"
+    ]
     "scheduler_opts" : {
         "n_jobs"        : -1,
         "partition"     : "ifarm",


### PR DESCRIPTION
Allows additional static command line arguments to be passed to the simulation and reconstruction through the json run config file.