### PR TITLE
Check for sim_args before applying

### DIFF
--- a/EICMOBOTestTools/SimGenerator.py
+++ b/EICMOBOTestTools/SimGenerator.py
@@ -103,8 +103,9 @@ class SimGenerator:
         output  = " --outputFile " + outDir + "/" + outFile
 
         otherArgs= ""
-        for arg in self.cfgRun["sim_args"]:
-            otherArgs = otherArgs + " " + arg
+        if "sim_args" in self.cfgRun["sim_args"]:
+            for arg in self.cfgRun["sim_args"]:
+                otherArgs = otherArgs + " " + arg
 
         # construct most of command
         command = self.cfgRun["sim_exec"] + compact + steerer + otherArgs


### PR DESCRIPTION
This PR adds a check on if `sim_args` was provided in the run config file before applying them in `EICMOBOTestTools/SimGenerator.py`.